### PR TITLE
[fix]ローディングアニメーションを都道府県ボタンだけにかぶせるように

### DIFF
--- a/view/src/components/layout/PrefectureButtons/PrefectureButtons.module.scss
+++ b/view/src/components/layout/PrefectureButtons/PrefectureButtons.module.scss
@@ -3,6 +3,9 @@
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     grid-gap: 1rem;
     justify-items: center;
+    position: relative;
+    padding: 1rem 0;
+    min-height: 30vh;
 }
 
 @media screen and (max-width: 768px) {

--- a/view/src/components/layout/PrefectureButtons/PrefectureButtons.tsx
+++ b/view/src/components/layout/PrefectureButtons/PrefectureButtons.tsx
@@ -1,4 +1,4 @@
-import { ToggleButton } from '../../common'
+import { ToggleButton, LoadingCard } from '../../common'
 import style from './PrefectureButtons.module.scss'
 
 interface Prefecture {
@@ -10,10 +10,11 @@ interface Props {
   prefectures: Prefecture[]
   selectedPrefectures: Prefecture[]
   setSelectedPrefectures: React.Dispatch<React.SetStateAction<Prefecture[]>>
+  isLoading: boolean
 }
 
 export default function PrefectureButtons(props: Props): JSX.Element {
-  const { prefectures, selectedPrefectures, setSelectedPrefectures } = props
+  const { prefectures, selectedPrefectures, setSelectedPrefectures, isLoading } = props
 
   const handleSelectPrefecture = (prefecture: Prefecture) => {
     if (
@@ -38,5 +39,10 @@ export default function PrefectureButtons(props: Props): JSX.Element {
     </ToggleButton>
   ))
 
-  return <div className={style.prefecture_container}>{prefectureButtons}</div>
+  return (
+    <div className={style.prefecture_container}>
+      {isLoading && <LoadingCard />}
+      {prefectureButtons}
+    </div>
+  )
 }

--- a/view/src/pages/index.tsx
+++ b/view/src/pages/index.tsx
@@ -55,12 +55,12 @@ export default function Home() {
     <div className={style.main_container}>
       <Card>
         <div className={style.prefecture_card}>
-          {isPrefectureLoading && <LoadingCard />}
           <h2 className={style.title}>Prefectures</h2>
           <PrefectureButtons
             prefectures={prefectures}
             selectedPrefectures={selectedPrefectures}
             setSelectedPrefectures={setSelectedPrefectures}
+            isLoading={isPrefectureLoading}
           />
         </div>
       </Card>

--- a/view/src/styles/index.module.scss
+++ b/view/src/styles/index.module.scss
@@ -10,7 +10,6 @@
     font-weight: bold;
     color: #333;
     margin: 0;
-    margin-bottom: 2rem;
 }
 
 .prefecture_card{


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #16

# 概要
<!-- 開発内容の概要を記載 -->
- ローディングアニメーションを都道府県ボタンだけにかぶせるようにした
- タイトルは覆わない

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ローディングした際に都道府県ボタンだけに被さるようになってるか
